### PR TITLE
Make compatible with Electron v5.0+

### DIFF
--- a/sample-midi-piano/index.js
+++ b/sample-midi-piano/index.js
@@ -8,7 +8,7 @@ let win
 
 function createWindow () {
   // Create the browser window.
-  win = new BrowserWindow({width: 640, height: 400})
+  win = new BrowserWindow({width: 640, height: 400, webPreferences: { nodeIntegration: true }})
 
   // and load the index.html of the app.
   win.loadURL(url.format({

--- a/sample-midi-player/index.js
+++ b/sample-midi-player/index.js
@@ -8,7 +8,7 @@ let win
 
 function createWindow () {
   // Create the browser window.
-  win = new BrowserWindow({width: 640, height: 400})
+  win = new BrowserWindow({width: 640, height: 400, webPreferences: { nodeIntegration: true }})
 
   // and load the index.html of the app.
   win.loadURL(url.format({


### PR DESCRIPTION
These samples did not work for me out of the box.
I did a clone of master and fresh install of Electron 6.0.12.

Without this patch, the console listed an error about 'require' not being defined.
With this patch, both samples work perfectly.